### PR TITLE
Autofix id's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 tmp
 .idea
 .history
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 tmp
 .idea
+.history

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,8 +31,10 @@ module.exports = function(grunt) {
         // Configuration to be run (and then tested).
         ensure_id: {
             options: {
-                elements : ['button', 'a'],
-                attrs : ['ng-click']
+                check: 'id',
+                elements: ['button', 'a'],
+                attrs: ['ng-click', 'ng-submit'],
+                autofix: true
             },
             main: {
                 src: ['test/html/pass.html']

--- a/README.md
+++ b/README.md
@@ -58,11 +58,15 @@ Default value: `['ng-click', 'ng-submit']`
 
 Which HTML elements which has the above attributes should have id attribute.
 
-#### options.check
+#### options.autofix
 Type: `boolean`
 Default value: `false`
 
-The attribute to be observed. Ex. 'id', 'ng-attr-id' or other id variants 
+Add ID to all detected items in the following format:
+
+nameFile_%element%_%numberFile%_%uniqueId% 
+
+Example (test-file.html): testFile_input_2_489
 
 ### Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ In your project's Gruntfile, add a section named `ensure_id` to the data object 
 grunt.initConfig({
   ensure_id: {
     options: {
+      check: 'id',
       elements : ['button', 'a'],
-      attrs : ['ng-click']
+      attrs: ['ng-click', 'ng-submit'],
+      autofix: true
     },
     main: {
       src: ['test/fixtures/*']
@@ -37,6 +39,12 @@ grunt.initConfig({
 ```
 
 ### Options
+
+#### options.check
+Type: `string`
+Default value: `id`
+
+The attribute to be observed. Ex. 'id', 'ng-attr-id' or other id variants 
 
 #### options.elements
 Type: `Array`
@@ -49,6 +57,12 @@ Type: `Array`
 Default value: `['ng-click', 'ng-submit']`
 
 Which HTML elements which has the above attributes should have id attribute.
+
+#### options.check
+Type: `boolean`
+Default value: `false`
+
+The attribute to be observed. Ex. 'id', 'ng-attr-id' or other id variants 
 
 ### Usage Examples
 
@@ -73,8 +87,10 @@ In this example, custom options are used to do something else with whatever else
 grunt.initConfig({
   ensure_id: {
     options: {
+      check: 'id',
       elements : ['button', 'a'],
-      attrs : ['ng-click']
+      attrs: ['ng-click'],
+      autofix: true
     },
     files: {
       'dest/default_options': ['src/testing', 'src/123'],

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Default value: `false`
 
 Add ID to all detected items in the following format:
 
-nameFile_%element%_%numberFile%_%uniqueId% 
+`nameFile_element_numberFile_uniqueId`
 
-Example (test-file.html): testFile_input_2_489
+Example (test-file.html): `testFile_input_2_489`
 
 ### Usage Examples
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   "dependencies": {
     "htmlparser2": "^3.8.3",
     "lodash.camelcase": "^4.3.0",
-    "replace": "^0.3.0"
+    "replace-in-file": "^2.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,13 @@
     "grunt": "~0.4.5"
   },
   "keywords": [
-    "id","grunt","validation"
+    "id",
+    "grunt",
+    "validation"
   ],
   "dependencies": {
-    "htmlparser2": "^3.8.3"
+    "htmlparser2": "^3.8.3",
+    "lodash.camelcase": "^4.3.0",
+    "replace": "^0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ensure-id",
   "description": "Ensures that all specified html elements has id attribute.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "homepage": "https://github.com/ezraroi/grunt-ensure-id",
   "author": {
     "name": "Roi Ezra",

--- a/tasks/ensure_id.js
+++ b/tasks/ensure_id.js
@@ -22,7 +22,7 @@ module.exports = function (grunt) {
             check: ['ng-attr-id'],
             elements: ['button', 'a', 'input', 'select'],
             attrs: ['ng-click', 'ng-submit'],
-            autofix: true
+            autofix: false
         });
 
         var currentFile, hasError = false, currentLine, index, countFile = 0, uniqueId = 0;

--- a/tasks/ensure_id.js
+++ b/tasks/ensure_id.js
@@ -19,7 +19,7 @@ module.exports = function (grunt) {
         /* jshint validthis: true */
 
         var options = this.options({
-            check: ['ng-attr-id'],
+            check: 'ng-attr-id',
             elements: ['button', 'a', 'input', 'select'],
             attrs: ['ng-click', 'ng-submit'],
             autofix: false
@@ -77,6 +77,7 @@ module.exports = function (grunt) {
                         copyCurrentLine = copyCurrentLine.replace(/\//g, '\\/');
                         copyCurrentLine = copyCurrentLine.replace(/\(/g, '\\(');
                         copyCurrentLine = copyCurrentLine.replace(/\)/g, '\\)');
+                        copyCurrentLine = copyCurrentLine.replace(/\|/g, '\\|');
                         var regexString = new RegExp(copyCurrentLine);
 
                         switch (name) {
@@ -98,6 +99,10 @@ module.exports = function (grunt) {
 
                             case 'a':
                                 var newId = nameFile + "_link_" + countFile + "_" + uniqueId;
+                                break;
+
+                            case 'input':
+                                var newId = "{{'" + nameFile + "_link_' + " + nameFile + ".index + '_' \| uniqueId }}";
                                 break;
 
                             case 'iframe':
@@ -148,6 +153,7 @@ module.exports = function (grunt) {
                         copyCurrentLine = copyCurrentLine.replace(/\//g, '\\/');
                         copyCurrentLine = copyCurrentLine.replace(/\(/g, '\\(');
                         copyCurrentLine = copyCurrentLine.replace(/\)/g, '\\)');
+                        copyCurrentLine = copyCurrentLine.replace(/\|/g, '\\|');
                         var regexString = new RegExp(copyCurrentLine);
 
                         switch (attribute) {

--- a/tasks/ensure_id.js
+++ b/tasks/ensure_id.js
@@ -7,8 +7,11 @@
  */
 
 'use strict';
-var htmlparser = require("htmlparser2");
-module.exports = function(grunt) {
+const htmlparser = require("htmlparser2");
+const replace = require('replace-in-file');
+const camelCase = require('lodash.camelcase');
+
+module.exports = function (grunt) {
 
     grunt.registerMultiTask('ensure_id', 'Ensures that all specified html elements has id attribute', checkHtml);
 
@@ -16,21 +19,23 @@ module.exports = function(grunt) {
         /* jshint validthis: true */
 
         var options = this.options({
-            elements : ['button', 'a', 'input', 'select'],
-            attrs : ['ng-click', 'ng-submit']
+            check: ['ng-attr-id'],
+            elements: ['button', 'a', 'input', 'select'],
+            attrs: ['ng-click', 'ng-submit'],
+            autofix: true
         });
 
-        var currentFile, hasError = false, currentLine, index;
+        var currentFile, hasError = false, currentLine, index, countFile = 0, uniqueId = 0;
         var parser = new htmlparser.Parser({
             onopentag: parseOpenTag
-        }, {decodeEntities: true});
+        }, { decodeEntities: true });
         grunt.log.debug('Found ' + this.files.length + ' file groups to check');
-        this.files.forEach(function(f) {
+        this.files.forEach(function (f) {
             f.src.filter(filterNonExistingFiles).map(parseFile);
         });
         parser.end();
         if (hasError) {
-            grunt.fail.warn('Found elements without id.');
+            grunt.fail.warn('Found elements without -> ' + options.check + '.');
         }
 
         function filterNonExistingFiles(filepath) {
@@ -47,26 +52,141 @@ module.exports = function(grunt) {
             currentFile = filepath;
             var lines = grunt.file.read(filepath);
             index = 1;
-            lines.split('\n').forEach(function(line) {
+            lines.split('\n').forEach(function (line) {
                 currentLine = line.replace('\r', '');
                 parser.parseComplete(currentLine);
                 index++;
             });
             grunt.log.debug('Finished file: ' + filepath);
+            countFile++;
         }
 
-        function parseOpenTag(name, attribs){
-            if (options.elements.indexOf(name) !== -1 && !attribs.hasOwnProperty('id')) {
-                grunt.log.warn(currentFile + ' Line ' + index + ': (' + name + ') ' + currentLine);
-                hasError = true;
+        function parseOpenTag(name, attribs) {
+            if (options.elements.indexOf(name) !== -1) {
+                if (!attribs.hasOwnProperty(options.check)) {
+                    if (options.autofix) {
+
+                        /* convert name file to camelCase */
+                        var regExpFileName = new RegExp(/[^/]*$/g);
+                        var nameFile = camelCase(regExpFileName.exec(currentFile.replace(/\.html/g, '')));
+
+                        /* replace the special characters of the html tag to be able to use it with regular expressions */
+                        var copyCurrentLine = currentLine;
+                        copyCurrentLine = copyCurrentLine.replace(/\"/g, '\\"');
+                        copyCurrentLine = copyCurrentLine.replace(/\./g, '\\.');
+                        copyCurrentLine = copyCurrentLine.replace(/\//g, '\\/');
+                        copyCurrentLine = copyCurrentLine.replace(/\(/g, '\\(');
+                        copyCurrentLine = copyCurrentLine.replace(/\)/g, '\\)');
+                        var regexString = new RegExp(copyCurrentLine);
+
+                        switch (name) {
+                            case 'button':
+                                var newId = nameFile + "_btn_" + countFile + "_" + uniqueId;
+                                break;
+
+                            case 'img':
+                                var newId = nameFile + "_img_" + countFile + "_" + uniqueId;
+                                break;
+
+                            case 'p':
+                                var newId = nameFile + "_text_" + countFile + "_" + uniqueId;
+                                break;
+
+                            case 'span':
+                                var newId = nameFile + "_span_" + countFile + "_" + uniqueId;
+                                break;
+
+                            case 'a':
+                                var newId = nameFile + "_link_" + countFile + "_" + uniqueId;
+                                break;
+
+                            case 'iframe':
+                                var newId = nameFile + "_iframe_" + countFile + "_" + uniqueId;
+                                break;
+
+                            default:
+                                var newId = nameFile + "_other_" + countFile + "_" + uniqueId;
+                                break;
+                        }
+                        uniqueId++;
+
+                        /* Prepare options to replace file */
+                        var replaceOptions = {
+                            files: currentFile,
+                            from: regexString,
+                            to: currentLine.replace('<' + name, '\<' + name + ' ' + options.check + '="' + newId + '"')
+                        };
+
+                        try {
+                            let changedFiles = replace.sync(replaceOptions);
+                            grunt.log.debug(currentFile + ' [AUTO FIX] Line ' + index + ': (' + name + ' with ' + attribute + ' -> without: ' + options.check + ')' + currentLine);
+                        }
+                        catch (error) {
+                            grunt.log.debug('Error occurred:', error);
+                        }
+                        hasError = false;
+                    } else {
+                        grunt.log.warn(currentFile + ' Line ' + index + ': (' + name + ' -> without: ' + options.check + ')' + currentLine);
+                        hasError = true;
+                    }
+                }
             }
-            options.attrs.forEach(function(attribute) {
-                if (attribs.hasOwnProperty(attribute) && !attribs.hasOwnProperty('id')) {
-                    grunt.log.warn(currentFile + ' Line ' + index + ': (' + name + ') ' + currentLine);
-                    hasError = true;
+
+            options.attrs.forEach(function (attribute) {
+                if (attribs.hasOwnProperty(attribute) && !attribs.hasOwnProperty(options.check)) {
+
+                    if (options.autofix) {
+
+                        /* convert name file to camelCase */
+                        var regExpFileName = new RegExp(/[^/]*$/g);
+                        var nameFile = camelCase(regExpFileName.exec(currentFile.replace(/\.html/g, '')));
+
+                        /* replace the special characters of the html tag to be able to use it with regular expressions */
+                        var copyCurrentLine = currentLine;
+                        copyCurrentLine = copyCurrentLine.replace(/\"/g, '\\"');
+                        copyCurrentLine = copyCurrentLine.replace(/\./g, '\\.');
+                        copyCurrentLine = copyCurrentLine.replace(/\//g, '\\/');
+                        copyCurrentLine = copyCurrentLine.replace(/\(/g, '\\(');
+                        copyCurrentLine = copyCurrentLine.replace(/\)/g, '\\)');
+                        var regexString = new RegExp(copyCurrentLine);
+
+                        switch (attribute) {
+                            case 'ng-click':
+                                var newId = nameFile + "_btn_" + countFile + "_" + uniqueId;
+                                break;
+                            case 'ng-submit':
+                                var newId = nameFile + "_btn_" + countFile + "_" + uniqueId;
+                                break;
+                            default:
+                                var newId = nameFile + "_other_" + countFile + "_" + uniqueId;
+                                break;
+                        }
+                        uniqueId++;
+
+                        /* Prepare options to replace file */
+                        var replaceOptions = {
+                            files: currentFile,
+                            from: regexString,
+                            to: currentLine.replace('<' + name, '\<' + name + ' ' + options.check + '="' + newId + '"')
+                        };
+
+                        try {
+                            let changedFiles = replace.sync(replaceOptions);
+                            grunt.log.debug(currentFile + ' [AUTO FIX] Line ' + index + ': (' + name + ' with ' + attribute + ' -> without: ' + options.check + ')' + currentLine);
+                        }
+                        catch (error) {
+                            grunt.log.debug('Error occurred:', error);
+                        }
+                        hasError = false;
+                    } else {
+                        grunt.log.warn(currentFile + ' Line ' + index + ': (' + name + ' with ' + attribute + ' -> without: ' + options.check + ')' + currentLine);
+                        hasError = true;
+                    }
+
                 }
             });
         }
+
     }
 
 


### PR DESCRIPTION
Add ID to all detected items in the following format:

> nameFile_element_numberFile_uniqueId

Example (test-file.html):
>testFile_input_2_489

Before ensure_id was prepared to only review the id attribute. In my case i needed watch 'ng-attr-id'.  Now id attribute is customizable.

Please check the changes and if you see that it can be improved we could speak it without problem to improve it.

Thanks a lot for your contribution! You've helped me detect an ids problem I had in my project.

I hope hearing from you soon